### PR TITLE
Allow users to open the filesystem with mode as 'wb' or 'rb'

### DIFF
--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -187,9 +187,9 @@ def removeattr(LFSFilesystem fs, path, type):
 
 
 def file_open(LFSFilesystem fs, path, flags):
-    if flags == 'w':
+    if flags in ('w', 'wb'):
         flags = LFS_O_WRONLY | LFS_O_CREAT
-    elif flags == 'r':
+    elif flags in ('r', 'rb'):
         flags = LFS_O_RDONLY
     else:
         raise NotImplementedError

--- a/test/lfs/test_file_functions.py
+++ b/test/lfs/test_file_functions.py
@@ -5,6 +5,10 @@ def test_file_open(mounted_fs):
     fh = lfs.file_open(mounted_fs, 'test.txt', 'w')
 
 
+def test_file_open_wb(mounted_fs):
+    fh = lfs.file_open(mounted_fs, 'test.txt', 'wb')
+
+
 def test_file_close(mounted_fs):
     fh = lfs.file_open(mounted_fs, 'test.txt', 'w')
     lfs.file_close(mounted_fs, fh)
@@ -21,6 +25,16 @@ def test_file_read(mounted_fs):
     lfs.file_close(mounted_fs, fh)
 
     fh = lfs.file_open(mounted_fs, 'test.txt', 'r')
+    data = lfs.file_read(mounted_fs, fh, 10)
+    assert data == b'0123456789'
+
+
+def test_file_read_rb(mounted_fs):
+    fh = lfs.file_open(mounted_fs, 'test.txt', 'w')
+    lfs.file_write(mounted_fs, fh, b'0123456789')
+    lfs.file_close(mounted_fs, fh)
+
+    fh = lfs.file_open(mounted_fs, 'test.txt', 'rb')
     data = lfs.file_read(mounted_fs, fh, 10)
     assert data == b'0123456789'
 


### PR DESCRIPTION
Currently users can only open the filesystem using the mode 'r' or
'w'. Since the file system is in binary mode (and not text mode) users
will expect that they can open using 'rb' or 'wb'.

This adds the ability to use 'rb' or 'wb' as the mode. Which act the
same as 'r' or 'w' respectively.