### PR TITLE
Bump littlefs to 2.6.1

### DIFF
--- a/test/test_version.py
+++ b/test/test_version.py
@@ -2,5 +2,5 @@ import littlefs
 
 def test_version():
     """Test if the versions of littlefs can be imported"""
-    assert littlefs.__LFS_VERSION__ == (2, 4)
-    assert littlefs.__LFS_DISK_VERSION__ == (2, 0)
+    assert littlefs.__LFS_VERSION__ == (2, 6)
+    assert littlefs.__LFS_DISK_VERSION__ == (2, 1)


### PR DESCRIPTION
Updates littlefs to the latest release, which incurs a disk version update. Tested locally with `pytest test`.