### PR TITLE
ARM prebuilt binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,58 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.1
+        uses: pypa/cibuildwheel@v2.12.3
 
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_wheels_macos_arm64:
+    name: Build ARM64 wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+        cibw_archs: ["arm64"]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.3
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_TEST_SKIP: "*-macosx_arm64"
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_REPAIR_WHEEL_COMMAND: |
+            echo "Target delocate archs: {delocate_archs}"
+
+            ORIGINAL_WHEEL={wheel}
+
+            echo "Running delocate-listdeps to list linked original wheel dependencies"
+            delocate-listdeps --all $ORIGINAL_WHEEL
+
+            echo "Renaming .whl file when architecture is 'macosx_arm64'"
+            RENAMED_WHEEL=${ORIGINAL_WHEEL//x86_64/arm64}
+
+            echo "Wheel will be renamed to $RENAMED_WHEEL"
+            mv $ORIGINAL_WHEEL $RENAMED_WHEEL
+
+            echo "Running delocate-wheel command on $RENAMED_WHEEL"
+            delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v $RENAMED_WHEEL
+
+            echo "Running delocate-listdeps to list linked wheel dependencies"
+            WHEEL_SIMPLE_FILENAME="${RENAMED_WHEEL##*/}"
+            delocate-listdeps --all {dest_dir}/$WHEEL_SIMPLE_FILENAME
+
+            echo "DONE."
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -32,10 +79,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Build sdist
-        run:  |
+        run: |
           pip install -r requirements.txt
           python setup.py sdist
 
@@ -44,7 +91,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_wheels_macos_arm64, build_sdist]
     runs-on: ubuntu-latest
     # if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
     steps:
@@ -52,8 +99,9 @@ jobs:
         with:
           name: artifact
           path: dist
-      
+
       - uses: pypa/gh-action-pypi-publish@v1.8.4
         with:
           user: __token__
           password: ${{ secrets.pypi_api_token }}
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       CIBW_BEFORE_BUILD: pip install -r requirements.txt
       CIBW_SKIP: "pp* *-win_arm64"
+      CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
 
     steps:
       - uses: actions/checkout@v3
@@ -104,4 +105,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_api_token }}
-

--- a/README.rst
+++ b/README.rst
@@ -83,8 +83,9 @@ This is as simple as it can be::
 At the moment wheels (which require no build) are provided for the following platforms,
 on other platforms the source package is used and a compiler is required:
 
- - Linux: Python 3.6 - 3.10 / 32- & 64-bit
- - Windows: Python 3.6 - 3.10 / 32- & 64-bit
+ - Linux: Python 3.6 - 3.11 / x86_64
+ - MacOS: Python 3.6 - 3.11 / x86_64, arm64
+ - Windows: Python 3.6 - 3.11 / 32- & 64-bit
 
 
 Development Setup

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ This is as simple as it can be::
 At the moment wheels (which require no build) are provided for the following platforms,
 on other platforms the source package is used and a compiler is required:
 
- - Linux: Python 3.6 - 3.11 / x86_64
+ - Linux: Python 3.6 - 3.11 / x86_64, arm64
  - MacOS: Python 3.6 - 3.11 / x86_64, arm64
  - Windows: Python 3.6 - 3.11 / 32- & 64-bit
 


### PR DESCRIPTION
Adds CI for building:
* MacOS ARM64 (M1/M2 macs) copied from my [python-template](https://github.com/BrianPugh/python-template).
    * It's a separate job because it has to implement a few workarounds.
* Linux ARM64 (helpful for many SBCs)
    * This significantly slows down the build process (maybe ~1hr?), but I think its worth it to make raspberry-pi people lives' easier.
* Update README with available prebuilt wheels