### PR TITLE
Bugfix noexcept (Cython 3.0.0 compatibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 venv/
+.venv/
 .direnv/
 .vscode/
 .tox/

--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -33,25 +33,25 @@ __LFS_VERSION__ = (LFS_VERSION_MAJOR, LFS_VERSION_MINOR)
 __LFS_DISK_VERSION__ = (LFS_DISK_VERSION_MAJOR, LFS_DISK_VERSION_MINOR)
 
 
-cdef int _lfs_read(const lfs_config *c, lfs_block_t block, lfs_off_t off, void * buffer, lfs_size_t size):
+cdef int _lfs_read(const lfs_config *c, lfs_block_t block, lfs_off_t off, void * buffer, lfs_size_t size) noexcept:
     ctx = <object>c.context
     data = ctx.user_context.read(ctx, block, off, size)
     memcpy(buffer, <char *>data, size)
     return 0
 
 
-cdef int _lfs_prog(const lfs_config *c, lfs_block_t block, lfs_off_t off, const void * buffer, lfs_size_t size):
+cdef int _lfs_prog(const lfs_config *c, lfs_block_t block, lfs_off_t off, const void * buffer, lfs_size_t size) noexcept:
     ctx = <object>c.context
     data = (<char*>buffer)[:size]
     return ctx.user_context.prog(ctx, block, off, data)
 
 
-cdef int _lfs_erase(const lfs_config *c, lfs_block_t block):
+cdef int _lfs_erase(const lfs_config *c, lfs_block_t block) noexcept:
     ctx = <object>c.context
     return ctx.user_context.erase(ctx, block)
 
 
-cdef int _lfs_sync(const lfs_config *c):
+cdef int _lfs_sync(const lfs_config *c) noexcept:
     ctx = <object>c.context
     return ctx.user_context.sync(ctx)
 


### PR DESCRIPTION
I tried installing this with python 3.11.4 on macos running on an M1 chip.

I was getting cython-related errors like:
```
Error compiling Cython file:
      ------------------------------------------------------------
      ...

          cdef lfs_config _impl
          cdef dict __dict__

          def __cinit__(self):
              self._impl.read = &_lfs_read
                                ^
      ------------------------------------------------------------

      src/littlefs/lfs.pyx:72:26: Cannot assign type 'int (*)(const lfs_config *, lfs_block_t, lfs_off_t, void *, lfs_size_t) except? -1' to 'int (*)(const lfs_config *, lfs_block_t, lfs_off_t, void *, lfs_size_t) noexcept'
```

I believe this is due to the [recent Cython 3.0.0 released on July 17, 2023](https://cython.readthedocs.io/en/latest/src/changes.html#exception-handling)

>Cython-implemented C functions now propagate exceptions by default, rather than swallowing them in non-object returning function if the user forgot to add an except declaration to the signature. This was a long-standing source of bugs, but can require adding the noexcept declaration to existing functions if exception propagation is really undesired. 


Environment:
```
$ python3 --version
Python 3.11.4

$ python3 -m pip list
Package           Version                      Editable project location
----------------- ---------------------------- -----------------------------------------
cachetools        5.3.1
chardet           5.1.0
colorama          0.4.6
Cython            3.0.0
distlib           0.3.7
filelock          3.12.2
iniconfig         2.0.0
packaging         23.1
pip               23.2.1
platformdirs      3.9.1
pluggy            1.2.0
pyproject-api     1.5.3
pytest            7.4.0
setuptools        67.6.1
setuptools-scm    7.1.0
tox               4.6.4
typing_extensions 4.7.1
virtualenv        20.24.1
```