### PR TITLE
Bumped littlefs to version 2.7.

### DIFF
--- a/test/test_version.py
+++ b/test/test_version.py
@@ -2,5 +2,5 @@ import littlefs
 
 def test_version():
     """Test if the versions of littlefs can be imported"""
-    assert littlefs.__LFS_VERSION__ == (2, 6)
+    assert littlefs.__LFS_VERSION__ == (2, 7)
     assert littlefs.__LFS_DISK_VERSION__ == (2, 1)


### PR DESCRIPTION
This PR bumps the littlefs to release 2.7, see changelog upstream:
https://github.com/littlefs-project/littlefs/releases/tag/v2.7.0

In short, this release brings in new `lfs_fs_stat` function and ability to choose on-disk version. I will create a separate PR for each of these features.

Tested with `pytest test` only.
