### PR TITLE
LFSConfig now uses proper keyword arguments

### DIFF
--- a/src/littlefs/__init__.py
+++ b/src/littlefs/__init__.py
@@ -22,12 +22,12 @@ if TYPE_CHECKING:
 class LittleFS:
     """Littlefs file system"""
 
-    def __init__(self, context:'UserContext'=None, **kwargs) -> None:
+    def __init__(self, context:'UserContext'=None, mount=True, **kwargs) -> None:
 
         self.cfg = lfs.LFSConfig(context=context, **kwargs)
         self.fs = lfs.LFSFilesystem()
 
-        if kwargs.get('mount', True):
+        if mount:
             try:
                 self.mount()
             except errors.LittleFSError:

--- a/src/littlefs/lfs.pyi
+++ b/src/littlefs/lfs.pyi
@@ -18,7 +18,22 @@ class LFSConfig:
 
     user_context: UserContext = ...
 
-    def __init__(self, context:UserContext=None, **kwargs) -> None: ...
+    def __init__(self,
+                 context=None,
+                 *,
+                 block_size: int = 128,
+                 block_count: int = 64,
+                 read_size: int = 0,
+                 prog_size: int = 0,
+                 block_cycles: int = -1,
+                 cache_size: int = 0,
+                 lookahead_size: int = 8,
+                 name_max: int = 0,
+                 file_max: int = 0,
+                 attr_max: int = 0,
+                 metadata_max: int = 0,
+                 disk_version: int = 0,
+                )-> None: ...
 
     @property
     def read_size(self) -> int: ...


### PR DESCRIPTION
low priority PR, just solidifies the LFSConfig constructor signature. No functional change.