### PR TITLE
Expose name max length to CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ EXTENSIONS = [
             ("LFS_NAME_MAX", "32767"),
             # ('LFS_YES_TRACE', '1')
         ],
-        extra_compile_args=["-std=c99"],
+        extra_compile_args=["-std=c99", "-UNDEBUG"],
     )
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ EXTENSIONS = [
             ("LFS_NO_WARN", "1"),
             ("LFS_NO_ERROR", "1"),
             ("LFS_MULTIVERSION", "1"),
-            ("LFS_NAME_MAX", "65535"),
+            ("LFS_NAME_MAX", "32767"),
             # ('LFS_YES_TRACE', '1')
         ],
         extra_compile_args=["-std=c99"],

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ EXTENSIONS = [
             ("LFS_NO_WARN", "1"),
             ("LFS_NO_ERROR", "1"),
             ("LFS_MULTIVERSION", "1"),
+            ("LFS_NAME_MAX", "65535"),
             # ('LFS_YES_TRACE', '1')
         ],
         extra_compile_args=["-std=c99"],

--- a/src/littlefs/__init__.py
+++ b/src/littlefs/__init__.py
@@ -1,6 +1,6 @@
 import io
 import warnings
-from typing import TYPE_CHECKING, List, Tuple, Iterator, IO, Union
+from typing import TYPE_CHECKING, List, Tuple, Iterator, IO, Union, Optional
 
 from pkg_resources import DistributionNotFound, get_distribution
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class LittleFS:
     """Littlefs file system"""
 
-    def __init__(self, context:'UserContext'=None, mount=True, **kwargs) -> None:
+    def __init__(self, context:Optional['UserContext']=None, mount=True, **kwargs) -> None:
 
         self.cfg = lfs.LFSConfig(context=context, **kwargs)
         self.fs = lfs.LFSFilesystem()

--- a/src/littlefs/__main__.py
+++ b/src/littlefs/__main__.py
@@ -16,7 +16,7 @@ def _fs_from_args(args: argparse.Namespace) -> LittleFS:
     return LittleFS(
         block_size=args.block_size,
         block_count=args.block_count,
-        max_name_len=args.max_name_len,
+        name_max=args.name_max,
     )
 
 def size_parser(size_str):
@@ -162,7 +162,7 @@ def get_parser():
         "--block-size", type=size_parser, required=True, help="LittleFS block size"
     )
     common_parser.add_argument(
-        "--max-name-len", type=size_parser, default=255, help="LittleFS max file path length."
+        "--name-max", type=size_parser, default=255, help="LittleFS max file path length."
     )
     group = common_parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--block-count", type=int, help="LittleFS block count")

--- a/src/littlefs/__main__.py
+++ b/src/littlefs/__main__.py
@@ -57,11 +57,11 @@ def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace):
 
     if args.verbose:
         print("LittleFS Configuration:")
-        print(f"  Block Size:   {args.block_size:6d}  /  0x{args.block_size:X}")
-        print(f"  Image Size:   {args.fs_size:6d}  /  0x{args.fs_size:X}")
-        print(f"  Block Count:  {args.block_count:6d}")
-        print(f"  Max Name Len: {args.max_name_len:6d}")
-        print(f"  Image:        {args.image}")
+        print(f"  Block Size:  {args.block_size:6d}  /  0x{args.block_size:X}")
+        print(f"  Image Size:  {args.fs_size:6d}  /  0x{args.fs_size:X}")
+        print(f"  Block Count: {args.block_count:6d}")
+        print(f"  Name Max:    {args.name_max:6d}")
+        print(f"  Image:       {args.image}")
 
 
 def create(parser: argparse.ArgumentParser, args: argparse.Namespace) -> int:

--- a/src/littlefs/__main__.py
+++ b/src/littlefs/__main__.py
@@ -57,10 +57,10 @@ def validate_args(parser: argparse.ArgumentParser, args: argparse.Namespace):
 
     if args.verbose:
         print("LittleFS Configuration:")
-        print(f"  Block Size:  {args.block_size:6d}  /  0x{args.block_size:X}")
-        print(f"  Image Size:  {args.fs_size:6d}  /  0x{args.fs_size:X}")
-        print(f"  Block Count: {args.block_count:6d}")
-        print(f"  Name Max:    {args.name_max:6d}")
+        print(f"  Block Size:  {args.block_size:9d}  /  0x{args.block_size:X}")
+        print(f"  Image Size:  {args.fs_size:9d}  /  0x{args.fs_size:X}")
+        print(f"  Block Count: {args.block_count:9d}")
+        print(f"  Name Max:    {args.name_max:9d}")
         print(f"  Image:       {args.image}")
 
 

--- a/src/littlefs/__main__.py
+++ b/src/littlefs/__main__.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import textwrap
 import pathlib
-from littlefs import LittleFS
+from littlefs import LittleFS, __version__
 
 # Dictionary mapping suffixes to their size in bytes
 _suffix_map = {
@@ -146,6 +146,7 @@ def get_parser():
         ),
         # formatter_class=argparse.RawTextHelpFormatter,
     )
+    parser.add_argument('--version', action='version', version=__version__)
 
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument("-v", "--verbose", action="count", default=0)
@@ -181,6 +182,7 @@ def get_parser():
 
 def main():
     parser = get_parser()
+    parser.parse_known_args(sys.argv[1:])  # Allows for ``littlefs-python --version``
     args = parser.parse_args(sys.argv[1:])
     return args.func(parser, args)
 

--- a/src/littlefs/lfs.pyi
+++ b/src/littlefs/lfs.pyi
@@ -28,7 +28,7 @@ class LFSConfig:
                  block_cycles: int = -1,
                  cache_size: int = 0,
                  lookahead_size: int = 8,
-                 name_max: int = 0,
+                 name_max: int = 255,
                  file_max: int = 0,
                  attr_max: int = 0,
                  metadata_max: int = 0,

--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -165,6 +165,24 @@ cdef class LFSConfig:
         self.user_context = context
         self._impl.context = <void *>self
 
+    def __repr__(self):
+        args = (
+            f"context={self.user_context!r}",
+            f"block_size={self._impl.block_size}",
+            f"block_count={self._impl.block_count}",
+            f"read_size={self._impl.read_size}",
+            f"prog_size={self._impl.prog_size}",
+            f"block_cycles={self._impl.block_cycles}",
+            f"cache_size={self._impl.cache_size}",
+            f"lookahead_size={self._impl.lookahead_size}",
+            f"name_max={self._impl.name_max}",
+            f"file_max={self._impl.file_max}",
+            f"attr_max={self._impl.attr_max}",
+            f"metadata_max={self._impl.metadata_max}",
+            f"disk_version={self._impl.disk_version}"
+        )
+        return f"{self.__class__.__name__}({', '.join(args)})"
+
     @property
     def read_size(self):
         return self._impl.read_size

--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -90,7 +90,7 @@ cdef class LFSConfig:
                  block_cycles: int = -1,
                  cache_size: int = 0,
                  lookahead_size: int = 8,
-                 name_max: int = 0,
+                 name_max: int = 255,
                  file_max: int = 0,
                  attr_max: int = 0,
                  metadata_max: int = 0,
@@ -134,6 +134,7 @@ cdef class LFSConfig:
             can track 8 blocks. Must be a multiple of 8.
             Defaults to 8.
         name_max: int
+            Defaults to 255 (LittleFS default).
         file_max: int
         attr_max: int
         metadata_max: int


### PR DESCRIPTION
This PR does a few things:

- Unrelated to anything else, I added `littlefs-python --version` to the cli.
- I increased `LFS_NAME_MAX` macro definition from the default `255` to `32767`.
    - Pros:
        - LittleFS supports any `name_max` configuration that is smaller than the version the driver was compiled with.
        - This effectively means that littlefs-python can support any reasonable use-case.
        - 32767 was chosen because it's the Windows maximum path length; I doubt any reasonable use-case would even approach this value.
    - Cons:
        - The `lfs_info` struct is now `32512` larger in `littlefs-python`. I don't think any reasonable user would care about this.
        - The `lfs_migrate` in `littlefs-python` also now uses `32512` more memory. This is a rarely used function, and also no reasonable user would care about this increase.
    - Additional Info:
        - LittleFS stores the config's `name_max` in it's superblock.
        - A LittleFS driver (understandably) cannot mount (it will return an error) a partition who has a superblock `name_max` larger than the `LFS_NAME_MAX` the driver was compiled with.
- I also exposed setting the `name_max` parameter in the CLI via `--name-max=255`.

I should have given more thought to this in the original CLI PR, but better late than never 😅 

This is the final blocker for the related esp_littlefs PR: https://github.com/joltwallet/esp_littlefs/pull/140