### PR TITLE
reduce LFS_NAME_MAX to 1022, the maximum valid value LittleFS supports.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ EXTENSIONS = [
             ("LFS_NO_WARN", "1"),
             ("LFS_NO_ERROR", "1"),
             ("LFS_MULTIVERSION", "1"),
-            ("LFS_NAME_MAX", "32767"),
+            ("LFS_NAME_MAX", "1022"),  # LittleFS limitation: must be <= 1022
             # ('LFS_YES_TRACE', '1')
         ],
         extra_compile_args=["-std=c99", "-UNDEBUG"],
@@ -39,9 +39,7 @@ setup(
     package_data={"*": ["py.typed", "*.pyi"]},
     package_dir={"": "src"},
     zip_safe=False,
-    ext_modules=cythonize(
-        EXTENSIONS, language_level=3, annotate=False, compiler_directives={"embedsignature": True}
-    ),
+    ext_modules=cythonize(EXTENSIONS, language_level=3, annotate=False, compiler_directives={"embedsignature": True}),
     entry_points={
         "console_scripts": [
             "littlefs-python = littlefs.__main__:main",

--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -144,6 +144,9 @@ cdef class LFSConfig:
         if block_size < 128:
             raise ValueError('Minimal block size is 128')
 
+        if name_max > 1022:  # LittleFS maximum name length limitation
+            raise ValueError(f"name_max must be <=1022.")
+
         self._impl.read_size = read_size if read_size else block_size
         self._impl.prog_size = prog_size if prog_size else block_size
         self._impl.block_size = block_size

--- a/test/test_name_max.py
+++ b/test/test_name_max.py
@@ -1,0 +1,30 @@
+import pytest
+from littlefs import lfs, LittleFS
+
+
+def test_name_max_gt_1022():
+    """Don't allow a `name_max > 1022`.
+
+    From the LittleFS documentation:
+
+        // Maximum name size in bytes, may be redefined to reduce the size of the
+        // info struct. Limited to <= 1022. Stored in superblock and must be
+        // respected by other littlefs drivers.
+
+    Originally reported:
+        https://github.com/jrast/littlefs-python/issues/61
+    """
+
+    with pytest.raises(ValueError):
+        LittleFS(name_max=1023)
+
+
+def test_name_max_0():
+    """Ensures that defaulting to ``LFS_NAME_MAX`` is valid.
+
+    Originally reported:
+        https://github.com/jrast/littlefs-python/issues/61
+    """
+    fs = LittleFS(name_max=0)
+    stat = fs.fs_stat()
+    assert stat.name_max == 1022


### PR DESCRIPTION
Addresses https://github.com/jrast/littlefs-python/issues/61