### PR TITLE
Fix typos/references (via Codespell)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Installation
 .. note::
     As littlefs_ is bundled with the package you will need to install the correct version of
     this package in successfully read or create images for your embedded system. If you start
-    from scratch the latest version is recommeded.
+    from scratch the latest version is recommended.
 
     .. csv-table::
         :header: "Package Version", "LittleFS Version", "LittleFS File System Version"
@@ -119,10 +119,10 @@ the package::
 Development Hints
 -----------------
 
-- Test should be run before commiting: `pytest test`
+- Test should be run before committing: `pytest test`
 - Mypy is used for typechecking. Run it also on the tests to catch more issues:
   `mypy src test test/lfs`
-- Mypy stubs can be generated with `stubgen src`. This will create a `out` direcotry
+- Mypy stubs can be generated with `stubgen src`. This will create a `out` directory
   containing the generated stub files.
 
 
@@ -133,7 +133,7 @@ NEW (with github deploy action):
 
 - Make sure the master branch is in the state you want it.
 - Create a new tag with the correct version number and push the tag to github
-- Start the "Build and Deploy Pacakge" workflow for the created tag on github
+- Start the "Build and Deploy Package" workflow for the created tag on github
 
 
 OUTDATED (without github deploy action):

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -62,9 +62,9 @@ Let's create some more files in a configuration folder:
     ...     fh.write(bytearray([0xAA, 0xBB] * 100))
     200
 
-As we wan't to place the files in a folder, the folder first needs to be created.
+As we want to place the files in a folder, the folder first needs to be created.
 The filesystem does not know the concept of a working directory. The working directory
-is allways assumed to be the root directory, therefore :code:`./config`, :code:`/config` and
+is always assumed to be the root directory, therefore :code:`./config`, :code:`/config` and
 :code:`config` have all the same meaning, use whatever you like the best.
 
 A final check to see if all required files are on the filesystem before we dump the data
@@ -90,7 +90,7 @@ This file can be written/downloaded to the actual storage.
 Inspecting a filesystem image
 =============================
 
-Sometimes it's necesary to inspect a filesystem which was previously in use
+Sometimes it's necessary to inspect a filesystem which was previously in use
 on a embedded system. Once the filesystem is available as an binary image, it's easy
 to inspect the content using littlefs-python.
 
@@ -109,7 +109,7 @@ After the buffer is initialized with the correct data, we can mount the filesyst
     >>> fs.mount()
     0
 
-Let's see whats on the filesystem:
+Let's see what's on the filesystem:
 
 .. doctest::
 
@@ -127,7 +127,7 @@ Ok, this seems to be fine. Let's check if the `actor` file was modified:
 Great, our memory contains the correct data!
 
 Now it's up to you! Play around with the data, try writing and reading other files,
-create directories or play around with differnt :code:`block_size` and :code:`block_count`
+create directories or play around with different :code:`block_size` and :code:`block_count`
 arguments.
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,7 +6,7 @@ littlefs-python offers three interfaces to the underlying littlefs library:
 
 - A C-Style API which exposes all functions from the library using a minimal
   wrapper, written in Cython, to access the functions.
-- A pythonic high-level API which offers convenient functions similiar to
+- A pythonic high-level API which offers convenient functions similar to
   the ones known from the :mod:`os` standard library module.
 - A command line tool, available as ``littlefs-python``. See :ref:`doc-cli`
   for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "Cython>=3.0.0", "setuptools_scm>=3.3.3"]
+
+[tool.codespell]
+skip = "src/littlefs/lfs.c"
+ignore-words-list = "wronly"

--- a/src/littlefs/__init__.py
+++ b/src/littlefs/__init__.py
@@ -329,18 +329,15 @@ class LittleFS:
 
         Generate the file and directory names in a directory tree by
         walking the tree top-down. This functions closely resembels the
-        behaviour of :func:`os.stat`.
+        behaviour of :func:`os.walk`.
 
         Each iteration yields a tuple containing three elements:
 
         - The root of the currently processed element
         - A list of directories located in the root
         - A list of filenames located in the root
-
         """
-        files = []
-        dirs = []
-        from os import walk
+        files, dirs = [], []
         for elem in self.scandir(top):
             if elem.type == 1:
                 files.append(elem.name)

--- a/src/littlefs/__init__.py
+++ b/src/littlefs/__init__.py
@@ -275,7 +275,7 @@ class LittleFS:
         """Remove directories recursively
 
         This works like :func:`remove` but if the leaf directory
-        is empty after the successfull removal of :attr:`name`, the
+        is empty after the successful removal of :attr:`name`, the
         function tries to recursively remove all parent directories
         which are also empty.
         """
@@ -334,7 +334,7 @@ class LittleFS:
         Each iteration yields a tuple containing three elements:
 
         - The root of the currently processed element
-        - A list of directorys located in the root
+        - A list of directories located in the root
         - A list of filenames located in the root
 
         """

--- a/src/littlefs/lfs.pxd
+++ b/src/littlefs/lfs.pxd
@@ -51,7 +51,7 @@ cdef extern from "lfs.h":
         LFS_F_DIRTY   = 0x010000 # File does not match storage
         LFS_F_WRITING = 0x020000 # File has been written since last flush
         LFS_F_READING = 0x040000 # File has been read since last flush
-        LFS_F_ERRED   = 0x080000 # An error occured during write
+        LFS_F_ERRED   = 0x080000 # An error occurred during write
         LFS_F_INLINE  = 0x100000 # Currently inlined in directory entry
         LFS_F_OPENED  = 0x200000 # File has been opened
 

--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -285,7 +285,7 @@ def fs_mkconsistent(LFSFilesystem fs):
 def remove(LFSFilesystem fs, path):
     """Remove a file or directory
 
-    If removing a direcotry, the directory must be empty.
+    If removing a directory, the directory must be empty.
     """
     return _raise_on_error(lfs_remove(&fs._impl, path.encode(FILENAME_ENCODING)))
 

--- a/test/lfs/conftest.py
+++ b/test/lfs/conftest.py
@@ -15,12 +15,12 @@ def cfg():
 
 @pytest.fixture(scope='function')
 def formated_fs(fs, cfg):
-    """fixutre for a formated filesystem"""
+    """fixutre for a formatted filesystem"""
     lfs.format(fs, cfg)
     yield fs
 
 @pytest.fixture(scope='function')
 def mounted_fs(formated_fs, cfg):
-    """fixture for a formated and mounted filesystem"""
+    """fixture for a formatted and mounted filesystem"""
     lfs.mount(formated_fs, cfg)
     yield formated_fs

--- a/test/lfs/test_fs_functions.py
+++ b/test/lfs/test_fs_functions.py
@@ -4,7 +4,7 @@ from littlefs.errors import LittleFSError
 
 
 def test_mount_unformatted(fs, cfg):
-    """Mounting a unformated filesystem should lead to an error -84
+    """Mounting a unformatted filesystem should lead to an error -84
     which means the filesystem is corrupted
     """
     with pytest.raises(LittleFSError) as excinfo:
@@ -14,7 +14,7 @@ def test_mount_unformatted(fs, cfg):
 
 
 def test_mount_formatted(fs, cfg):
-    """Mounting a formated filesystem should work as expected"""
+    """Mounting a formatted filesystem should work as expected"""
     lfs.format(fs, cfg)
     assert lfs.mount(fs, cfg) == 0
 

--- a/test/test_attr.py
+++ b/test/test_attr.py
@@ -11,7 +11,7 @@ def fs():
 
 
 def test_attr(fs):
-    # Test if 2 attributes can be set without impacting eachother.
+    # Test if 2 attributes can be set without impacting each other.
     fs.setattr("/file.txt", "f", b"foo")
     fs.setattr("/file.txt", "b", b"bar")
 

--- a/test/test_remove_rename.py
+++ b/test/test_remove_rename.py
@@ -47,9 +47,9 @@ def test_remove(fs):
 
     # Remove a directory which does not exist (with leading slash)
     with pytest.raises(FileNotFoundError) as excinfo:
-        fs.remove('/dir/directroy/')
+        fs.remove('/dir/directory/')
     assert 'LittleFSError -2' in str(excinfo.value)
-    assert '/dir/directroy/' in str(excinfo.value)
+    assert '/dir/directory/' in str(excinfo.value)
 
 
 def test_removedirs(fs):


### PR DESCRIPTION
I added a terse configuration for [Codespell](https://github.com/codespell-project/codespell) to the pyproject.toml, and fixed the identified typos.

I also fixed an incorrect documentation reference where `os.walk` was intended.