### PR TITLE
add recursive=False flag to remove method

### DIFF
--- a/test/test_remove_rename.py
+++ b/test/test_remove_rename.py
@@ -52,6 +52,13 @@ def test_remove(fs):
     assert '/dir/directroy/' in str(excinfo.value)
 
 
+def test_remove_recursive(fs):
+    fs.remove("/dir", recursive=True)
+    with pytest.raises(errors.LittleFSError) as excinfo:
+        fs.stat("/dir")
+    assert "LittleFSError -2" in str(excinfo.value)
+
+
 def test_removedirs(fs):
     fs.removedirs('/dir/sub/file.txt')
     assert set(fs.listdir('/dir')) == {'emptyA', 'emptyB', 'file.txt'}


### PR DESCRIPTION
Allows for recursively deleting a directory.

Technically, by changing the return value from `int` to `None`, this is a backwards incompatible change, but the previous return value could only ever be `0` as negative values are promoted to exceptions. I don't imagine this would impact any reasonable use-case.