### PR TITLE
update python 3.12 identifier and readme. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,9 @@ This is as simple as it can be::
 At the moment wheels (which require no build) are provided for the following platforms,
 on other platforms the source package is used and a compiler is required:
 
- - Linux: Python 3.6 - 3.11 / x86_64, arm64
- - MacOS: Python 3.6 - 3.11 / x86_64, arm64
- - Windows: Python 3.6 - 3.11 / 32- & 64-bit
+ - Linux: Python 3.8 - 3.12 / x86_64, arm64
+ - MacOS: Python 3.8 - 3.12 / x86_64, arm64
+ - Windows: Python 3.8 - 3.12 / 32- & 64-bit
 
 
 Development Setup

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Embedded Systems",
         "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
CI is already building 3.12 wheels. So this is just metadata/readme updates.