### PR TITLE
Use NamedTuple instead of namedtuple in lfs.pyx.

### DIFF
--- a/src/littlefs/lfs.pxd
+++ b/src/littlefs/lfs.pxd
@@ -55,6 +55,10 @@ cdef extern from "lfs.h":
         LFS_F_INLINE  = 0x100000 # Currently inlined in directory entry
         LFS_F_OPENED  = 0x200000 # File has been opened
 
+    cdef enum lfs_type:
+        # littlefs-python: Only exporting public values for now.
+        LFS_TYPE_REG = 0x001
+        LFS_TYPE_DIR = 0x002
 
     cdef struct lfs:
         lfs_size_t block_count

--- a/src/littlefs/lfs.pyi
+++ b/src/littlefs/lfs.pyi
@@ -6,69 +6,63 @@ FILENAME_ENCODING: str = ...
 __LFS_VERSION__: Tuple[int, int] = ...
 __LFS_DISK_VERSION__: Tuple[int, int] = ...
 
-LFSStat = NamedTuple('LFSStat', [
-    ('type', int),
-    ('size', int),
-    ('name', str)
-])
+class LFSStat(NamedTuple):
+    type: int
+    size: int
+    name: str
 
-LFSFSStat = NamedTuple('LFSFSStat', [
-    'disk_version',
-    'name_max',
-    'file_max',
-    'attr_max',
-    'block_count',
-    'block_size',
-])
+    # Constants
+    TYPE_REG: int = LFS_TYPE_REG
+    TYPE_DIR: int = LFS_TYPE_DIR
 
+class LFSFSStat(NamedTuple):
+    """Littlefs filesystem status."""
+
+    disk_version: int
+    name_max: int
+    file_max: int
+    attr_max: int
+    block_count: int
+    block_size: int
 
 class LFSFileFlag(enum.IntFlag): ...
 
 class LFSConfig:
-
     user_context: UserContext = ...
 
-    def __init__(self,
-                 context=None,
-                 *,
-                 block_size: int = 128,
-                 block_count: int = 64,
-                 read_size: int = 0,
-                 prog_size: int = 0,
-                 block_cycles: int = -1,
-                 cache_size: int = 0,
-                 lookahead_size: int = 8,
-                 name_max: int = 255,
-                 file_max: int = 0,
-                 attr_max: int = 0,
-                 metadata_max: int = 0,
-                 disk_version: int = 0,
-                )-> None: ...
-
+    def __init__(
+        self,
+        context=None,
+        *,
+        block_size: int = 128,
+        block_count: int = 64,
+        read_size: int = 0,
+        prog_size: int = 0,
+        block_cycles: int = -1,
+        cache_size: int = 0,
+        lookahead_size: int = 8,
+        name_max: int = 255,
+        file_max: int = 0,
+        attr_max: int = 0,
+        metadata_max: int = 0,
+        disk_version: int = 0,
+    ) -> None: ...
     @property
     def read_size(self) -> int: ...
-
     @property
     def prog_size(self) -> int: ...
-
     @property
     def block_size(self) -> int: ...
-
     @property
     def block_count(self) -> int: ...
-
     @property
     def cache_size(self) -> int: ...
-
     @property
     def lookahead_size(self) -> int: ...
-
     @property
     def name_max(self) -> int: ...
-
     @property
     def file_max(self) -> int: ...
-
     @property
     def attr_max(self) -> int: ...
 
@@ -80,7 +74,6 @@ class LFSFilesystem:
 class LFSFile: ...
 class LFSDirectory: ...
 
-
 def fs_stat(fs: LFSFilesystem) -> LFSFSStat: ...
 def fs_size(fs: LFSFilesystem) -> int: ...
 def format(fs: LFSFilesystem, cfg: LFSConfig) -> int: ...
@@ -88,7 +81,6 @@ def mount(fs: LFSFilesystem, cfg: LFSConfig) -> int: ...
 def unmount(fs: LFSFilesystem) -> int: ...
 def fs_mkconsistent(fs: LFSFilesystem) -> int: ...
 def fs_grow(fs: LFSFilesystem, block_count) -> int: ...
-
 def remove(fs: LFSFilesystem, path: str) -> int: ...
 def rename(fs: LFSFilesystem, oldpath: str, newpath: str) -> int: ...
 def stat(fs: LFSFilesystem, path: str) -> LFSStat: ...
@@ -100,6 +92,7 @@ def removeattr(fs: LFSFilesystem, path: str, typ) -> None: ...
 
 # File Handling
 def file_open(fs: LFSFilesystem, path: str, flags: Union[str, LFSFileFlag]) -> LFSFile: ...
+
 # def file_open_cfg(self, path, flags, config): ...
 def file_close(fs: LFSFilesystem, fh: LFSFile) -> int: ...
 def file_sync(fs: LFSFilesystem, fh: LFSFile) -> int: ...

--- a/src/littlefs/lfs.pyx
+++ b/src/littlefs/lfs.pyx
@@ -1,6 +1,6 @@
 import logging
 import enum
-from collections import namedtuple
+from typing import NamedTuple
 # Import all definitions
 # from littlefs._lfs cimport *
 
@@ -11,22 +11,25 @@ from littlefs import errors
 FILENAME_ENCODING = 'ascii'
 """Default filename encoding"""
 
-LFSStat = namedtuple('LFSStat', ['type', 'size', 'name'])
-LFSStat.__doc__ = """\
-Littlefs File / Directory status
-"""
+class LFSStat(NamedTuple):
+    """Littlefs File / Directory status."""
+    type: int
+    size: int
+    name: str
 
-LFSFSStat = namedtuple('LFSFSStat', [
-    'disk_version',
-    'name_max',
-    'file_max',
-    'attr_max',
-    'block_count',
-    'block_size',
-])
-LFSFSStat.__doc__ = """\
-Littlefs filesystem status
-"""
+    # Constants
+    TYPE_REG = LFS_TYPE_REG
+    TYPE_DIR = LFS_TYPE_DIR
+
+
+class LFSFSStat(NamedTuple):
+    """Littlefs filesystem status."""
+    disk_version: int
+    name_max: int
+    file_max: int
+    attr_max: int
+    block_count: int
+    block_size: int
 
 
 class LFSFileFlag(enum.IntFlag):

--- a/test/lfs/test_fs_functions.py
+++ b/test/lfs/test_fs_functions.py
@@ -47,6 +47,10 @@ def test_stat_file(mounted_fs):
     assert stat.type == 1
     assert stat.name == "test.txt"
 
+    # Double checking that these constant got passed through.
+    assert stat.TYPE_REG == 0x001
+    assert stat.TYPE_DIR == 0x002
+
 
 def test_fs_stat(mounted_fs):
     """Test if fs stat works"""


### PR DESCRIPTION
- Added TYPE_REG and TYPE_DIR as constants to the LFSStat class.