### PR TITLE
Remove the f-string self-documenting expression for better Python 3.7 support

### DIFF
--- a/src/littlefs/__init__.py
+++ b/src/littlefs/__init__.py
@@ -99,7 +99,7 @@ class LittleFS:
 
     def fs_grow(self, block_count: int) -> int:
         if block_count < self.block_count:
-            raise ValueError(f"Supplied {block_count=} cannot be smaller than current block_count {self.block_count}")
+            raise ValueError(f"Supplied block_count='{block_count}' cannot be smaller than current block_count {self.block_count}")
 
         return lfs.fs_grow(self.fs, block_count)
 


### PR DESCRIPTION
Hello.

I know Python 3.7 isn't officially supported, but it seems to work with this small change. It would be great if this change gets accepted because then it would make it easier to integrate with esp-idf versions v5.0 and v5.1, because their minimal Python version is indeed 3.7 (only the latest esp-idf v5.2 bumps this to 3.8).

The current f-string = self-documenting expression breaks our internal CI when trying to backport official littlefs example from v5.2 to v5.1 and v5.0 because they use the older Python version.

Thank you!