### PR TITLE
Avoid undefined LFS_TYPE_REG/DIR.

### DIFF
--- a/src/littlefs/lfs.pyi
+++ b/src/littlefs/lfs.pyi
@@ -12,8 +12,8 @@ class LFSStat(NamedTuple):
     name: str
 
     # Constants
-    TYPE_REG: int = LFS_TYPE_REG
-    TYPE_DIR: int = LFS_TYPE_DIR
+    TYPE_REG: int
+    TYPE_DIR: int
 
 class LFSFSStat(NamedTuple):
     """Littlefs filesystem status."""

--- a/src/littlefs/lfs.pyi
+++ b/src/littlefs/lfs.pyi
@@ -12,8 +12,8 @@ class LFSStat(NamedTuple):
     name: str
 
     # Constants
-    TYPE_REG: int
-    TYPE_DIR: int
+    TYPE_REG: int = ...
+    TYPE_DIR: int = ...
 
 class LFSFSStat(NamedTuple):
     """Littlefs filesystem status."""


### PR DESCRIPTION
It seems all versions of mypy between 1.0.1 and 1.9.0 crash due to this definition ( https://github.com/python/mypy/issues/17059 ).

This seems to be a workaround. However, I'm not sure if the `lfs.pyi` is auto-generated or hand-written. There may be a better solution to this.