### PR TITLE
Rework CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ from scratch the latest version is recommended.
 .. csv-table::
     :header: "LittleFS Version", "Package Version", "LittleFS File System Version"
 
+    2.9.0, v0.11.X, 2.0 / 2.1 [#f1]_
     2.9.0, v0.10.X, 2.0 / 2.1 [#f1]_
     2.8.0, 0.8.X-0.9.X, 2.0 / 2.1 [#f1]_
     2.7.0, 0.7.X, 2.0 / 2.1 [#f1]_
@@ -92,6 +93,44 @@ on other platforms the source package is used and a compiler is required:
 + MacOS: Python 3.8 - 3.12 / x86_64, arm64
 + Windows: Python 3.8 - 3.12 / 32- & 64-bit
 
+CLI
+===
+littlefs-python comes bundled with a command-line tool, ``littlefs-python``, that can be used to create and extract littlefs binary images.
+
+.. code:: console
+
+   $ littlefs-python --help
+   usage: littlefs-python [-h] [--version] {create,extract,list} ...
+
+   Create, extract and inspect LittleFS filesystem images. Use one of the
+   commands listed below, the '-h' / '--help' option can be used on each command
+   to learn more about the usage.
+
+   optional arguments:
+     -h, --help            show this help message and exit
+     --version             show program's version number and exit
+
+   Available Commands:
+     {create,extract,list}
+       create              Create LittleFS image from file/directory contents.
+       extract             Extract LittleFS image contents to a directory.
+       list                List LittleFS image contents.
+
+To create a littlefs binary image:
+
+.. code:: console
+
+   # Creates a 1-megabyte "lfs.bin" containing README.rst
+   $ littlefs-python create README.rst lfs.bin --fs-size=1mb --block-size=4096
+
+   # Creates a 1-megabyte "lfs.bin" containing the contents of the examples/ folder
+   $ littlefs-python create examples lfs.bin --fs-size=1mb --block-size=4096
+
+To extract the contents of a littlefs binary image:
+
+.. code:: console
+
+   $ littlefs-python extract lfs.bin output/ --block-size=4096
 
 Development Setup
 =================

--- a/src/littlefs/__init__.py
+++ b/src/littlefs/__init__.py
@@ -99,7 +99,9 @@ class LittleFS:
 
     def fs_grow(self, block_count: int) -> int:
         if block_count < self.block_count:
-            raise ValueError(f"Supplied block_count='{block_count}' cannot be smaller than current block_count {self.block_count}")
+            raise ValueError(
+                f"Supplied block_count='{block_count}' cannot be smaller than current block_count {self.block_count}"
+            )
 
         return lfs.fs_grow(self.fs, block_count)
 


### PR DESCRIPTION
@jrast In this PR I reworked the CLI a bit to (IMHO) be a bit more intuitive to use. There is no longer as many unified keyword options, but each command now has positional arguments in the order you would expect them. Also, more information (such as block-count) is now inferred from the context.

Since this is all breaking changes, I would also be tempted to rename `create` to `pack` to use the same language as the `unpack` command.