### PR TITLE
have ci build cp37 wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     env:
-      CIBW_SKIP: "cp36-* cp37-* pp* *-win_arm64 *-musllinux_aarch64"
+      CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* pp37-* pp38-* pp39-* pp310-*"
+      CIBW_SKIP: "cp36-* pp* *-win_arm64 *-musllinux_aarch64"
       CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
 
     steps:
@@ -49,7 +50,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.1
         env:
           CIBW_BUILD: ${{ matrix.cibw_build }}
-          CIBW_SKIP: "cp36-* cp37-*"
+          CIBW_SKIP: "cp36-* pp*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_REPAIR_WHEEL_COMMAND: |
             echo "Target delocate archs: {delocate_archs}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        os: [ubuntu-latest, macos-13, windows-latest]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,9 @@ This is as simple as it can be::
 At the moment wheels (which require no build) are provided for the following platforms,
 on other platforms the source package is used and a compiler is required:
 
-+ Linux: Python 3.8 - 3.12 / x86_64, arm64
-+ MacOS: Python 3.8 - 3.12 / x86_64, arm64
-+ Windows: Python 3.8 - 3.12 / 32- & 64-bit
++ Linux: Python 3.7 - 3.12 / x86_64, arm64
++ MacOS: Python 3.7 - 3.12 / x86_64, arm64
++ Windows: Python 3.7 - 3.12 / 32- & 64-bit
 
 CLI
 ===


### PR DESCRIPTION
I've had a little bit of a change of heart; may as well support python 3.7 as long as esp-idf does. No need to make people using espressif chips lives more difficult.