### PR TITLE
block-size should be required on list command

### DIFF
--- a/src/littlefs/__main__.py
+++ b/src/littlefs/__main__.py
@@ -295,6 +295,7 @@ def get_parser():
     parser_list.add_argument(
         "--block-size",
         type=size_parser,
+        required=True,
         help="LittleFS block size.",
     )
 


### PR DESCRIPTION
When listing contents of a littlefs-binary, `littlefs-python` throws an error, when the block-size argument is not passed.
```
$ littlefs-python list fs.bin                                                                                    Mi 12 Feb 2025 06:38:19 CET
Traceback (most recent call last):
  File "/nix/store/71b4kzb409hl1p1a0p6kca0czd1nc4ds-python3.12-littlefs-python-0.13.1/bin/.littlefs-python-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/71b4kzb409hl1p1a0p6kca0czd1nc4ds-python3.12-littlefs-python-0.13.1/lib/python3.12/site-packages/littlefs/__main__.py", line 308, in main
    return args.func(parser, args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/71b4kzb409hl1p1a0p6kca0czd1nc4ds-python3.12-littlefs-python-0.13.1/lib/python3.12/site-packages/littlefs/__main__.py", line 124, in _list
    fs = _fs_from_args(args, mount=False)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/71b4kzb409hl1p1a0p6kca0czd1nc4ds-python3.12-littlefs-python-0.13.1/lib/python3.12/site-packages/littlefs/__main__.py", line 19, in _fs_from_args
    return LittleFS(
           ^^^^^^^^^
  File "/nix/store/71b4kzb409hl1p1a0p6kca0czd1nc4ds-python3.12-littlefs-python-0.13.1/lib/python3.12/site-packages/littlefs/__init__.py", line 61, in __init__
    self.cfg = lfs.LFSConfig(context=context, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Argument 'block_size' has incorrect type (expected int, got NoneType)
```
Making the argument required should avoid confusion, especially if the argument is required on the other subcommands.